### PR TITLE
Update term for DODOUD concept

### DIFF
--- a/res/dicts/dict.txt
+++ b/res/dicts/dict.txt
@@ -13983,4 +13983,4 @@
 43002|wouldn't mind not waking up|PPAIN|0411402
 43003|write a suicide|PPAIN|0411402
 43004|wrote a suicide|PPAIN|0411402
-44000|#percdata_oud#|DODOUD|report
+44000|PERCDATA_NO_OUD|DODOUD|report


### PR DESCRIPTION
Change from "#percdata_oud#" to "PERCDATA_NO_OUD" in dict.txt. Keep as upper case to distinguish from clinical terms.